### PR TITLE
feat: overrideable movement

### DIFF
--- a/src/objects/tank/player/player.cpp
+++ b/src/objects/tank/player/player.cpp
@@ -39,23 +39,38 @@ void Player::drawPlayer(Renderer &renderer)
 
 void Player::handleKeyboardEvent(const KeyboardEvent &ev)
 {
-    KeyboardEvent::KeyState key_state = ev.keyState();
-    if (key_state == KeyboardEvent::PRESSED || key_state == KeyboardEvent::RELEASED)
-    {
-        KeyCode key_code = ev.keyCode();
-        bool pressed = (key_state == KeyboardEvent::PRESSED);
+    if (ev.keyState() != KeyboardEvent::PRESSED && ev.keyState() != KeyboardEvent::RELEASED)
+        return;
 
-        if (key_code == m_key_state_up.key)
-            m_key_state_up.pressed = pressed;
-        else if (key_code == m_key_state_down.key)
-            m_key_state_down.pressed = pressed;
-        else if (key_code == m_key_state_left.key)
-            m_key_state_left.pressed = pressed;
-        else if (key_code == m_key_state_right.key)
-            m_key_state_right.pressed = pressed;
-        else if (key_code == m_key_state_fire.key)
-            m_key_state_fire.pressed = pressed;
+    KeyCode key_code = ev.keyCode();
+    bool pressed = (ev.keyState() == KeyboardEvent::PRESSED);
+
+    if (key_code == m_key_state_fire.key)
+    {
+        m_key_state_fire.pressed = pressed;
+        return;
     }
+
+    auto updateDir = [&](auto &state, Direction dir) -> bool
+    {
+        if (key_code == state.key)
+        {
+            state.pressed = pressed;
+            if (pressed)
+                m_last_pressed_direction = dir;
+            return true;
+        }
+        return false;
+    };
+
+    if (updateDir(m_key_state_up, D_UP))
+        return;
+    if (updateDir(m_key_state_down, D_DOWN))
+        return;
+    if (updateDir(m_key_state_left, D_LEFT))
+        return;
+    if (updateDir(m_key_state_right, D_RIGHT))
+        return;
 }
 
 void Player::update(Uint32 dt)

--- a/src/objects/tank/player/player.h
+++ b/src/objects/tank/player/player.h
@@ -53,6 +53,8 @@ private:
     KeyState m_key_state_right;
     KeyState m_key_state_fire;
 
+    Direction m_last_pressed_direction;
+
     // Sub-states
     class CreatingState : public ContextState<Player>
     {

--- a/src/objects/tank/player/player_alive_state.cpp
+++ b/src/objects/tank/player/player_alive_state.cpp
@@ -52,7 +52,29 @@ void Player::AliveState::checkKeyStates(const UpdateState &updateState)
 {
     Player *player = m_context;
 
-    if (player->m_key_state_up.pressed)
+    auto isPressed = [&](Direction d)
+    {
+        switch (d)
+        {
+        case D_UP:
+            return player->m_key_state_up.pressed;
+        case D_DOWN:
+            return player->m_key_state_down.pressed;
+        case D_LEFT:
+            return player->m_key_state_left.pressed;
+        case D_RIGHT:
+            return player->m_key_state_right.pressed;
+        default:
+            return false;
+        }
+    };
+
+    if (isPressed(player->m_last_pressed_direction))
+    {
+        player->setDirection(player->m_last_pressed_direction);
+        player->m_speed = player->m_max_speed;
+    }
+    else if (player->m_key_state_up.pressed)
     {
         player->setDirection(D_UP);
         player->m_speed = player->m_max_speed;


### PR DESCRIPTION
Tracking current direction to allow changing movement direction without releasing the previous keys.
Perhaps there's a cleaner way to do this without adding a new member to the Player class but it works!

CLOSES: https://github.com/krystiankaluzny/Tanks/issues/26